### PR TITLE
Codeblock: check for non-existent lang for highlighting

### DIFF
--- a/src/CodeBlock/CodeBlock.stories.js
+++ b/src/CodeBlock/CodeBlock.stories.js
@@ -20,8 +20,8 @@ export const normal = () => ({
       <code-block :value="data.short"/>
       <p>Multiline snippet with syntax highlighting:</p>
       <code-block :value="data.medium" language="go"/>
-      <p>Multiline snippet with syntax highlighting and expand button:</p>
-      <code-block :value="data.long" :url="url" language="go"/>
+      <p>Multiline snippet with an expand button:</p>
+      <code-block :value="data.long" :url="url" language="xyz"/>
     </div>
   `
 });

--- a/src/CodeBlock/CodeBlock.vue
+++ b/src/CodeBlock/CodeBlock.vue
@@ -107,6 +107,7 @@ span {
   scrollbar-color: rgba(255,255,255,.2) rgba(255,255,255,.1);
   scrollbar-width: thin;
   font-size: 0.8125rem;
+  line-height: 1.25rem;
 }
 
 .body::-webkit-scrollbar {
@@ -130,6 +131,7 @@ span {
   font-family: 'Menlo', 'Monaco', 'Fira Code', monospace;
   font-size: 0.8125rem;
   display: inline-block;
+  line-height: 1.25rem;
 }
 .body.body__hasfooter__true {
   border-bottom-left-radius: 0;

--- a/src/CodeBlock/CodeBlock.vue
+++ b/src/CodeBlock/CodeBlock.vue
@@ -385,10 +385,13 @@ export default {
         this.copied = false;
       }, 2000);
     },
-    highlighted(value) {
-      return this.language
-        ? Prism.highlight(value, Prism.languages[this.language])
-        : value
+    highlighted(source) {
+      const supportedSyntax = Prism.languages[this.language]
+      if (supportedSyntax) {
+        return Prism.highlight(source, supportedSyntax)
+      } else {
+        return source
+      }
     },
     expand(bool, scroll) {
       const container = this.$refs.container;

--- a/src/CodeBlock/CodeBlock.vue
+++ b/src/CodeBlock/CodeBlock.vue
@@ -99,13 +99,14 @@ span {
   overflow-x: scroll;
   padding-left: 1rem;
   padding-right: 1rem;
-  padding-top: 1rem;
+  padding-top: 1.375rem;
   padding-bottom: 1rem;
   overflow-y: hidden;
   position: relative;
   line-height: 1.75;
   scrollbar-color: rgba(255,255,255,.2) rgba(255,255,255,.1);
   scrollbar-width: thin;
+  font-size: 0.8125rem;
 }
 
 .body::-webkit-scrollbar {
@@ -127,7 +128,7 @@ span {
 }
 .body__wrapper {
   font-family: 'Menlo', 'Monaco', 'Fira Code', monospace;
-  font-size: 0.785rem;
+  font-size: 0.8125rem;
   display: inline-block;
 }
 .body.body__hasfooter__true {
@@ -149,7 +150,7 @@ span {
   box-sizing: border-box;
 }
 .codeblock__expanded__false .expand {
-  background: linear-gradient(to top, #2e3148, rgba(46,49,72,0));
+  background: linear-gradient(180deg, rgba(22, 25, 49, 0) 0%, #161931 100%);
 }
 .expand__item {
   text-transform: uppercase;


### PR DESCRIPTION
Fixes an error when `language` prop receives a language Prism doesn't know about:

```html
<code-block :value="data.long" :url="url" language="xyz"/>
```

The error:

<img width="1370" alt="Screenshot 2020-03-08 at 18 25 35" src="https://user-images.githubusercontent.com/332151/76163708-4d540100-616a-11ea-95a4-7f4373aaa419.png">