### PR TITLE
Codeblock: base64 prop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cosmos-ui/vue",
-  "version": "0.7.0",
+  "version": "0.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8665,6 +8665,11 @@
           }
         }
       }
+    },
+    "js-base64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.2.tgz",
+      "integrity": "sha512-Vg8czh0Q7sFBSUMWWArX/miJeBWYBPpdU/3M/DKSaekLMqrqVPaedp+5mZhie/r0lgrcaYBfwXatEew6gwgiQQ=="
     },
     "js-string-escape": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "clipboard-copy": "^3.1.0",
+    "js-base64": "^2.5.2",
     "prismjs": "^1.19.0",
     "tiny-cookie": "^2.3.1",
     "vue": "^2.6.10"

--- a/src/CodeBlock/CodeBlock.stories.js
+++ b/src/CodeBlock/CodeBlock.stories.js
@@ -12,6 +12,7 @@ export const normal = () => ({
     return {
       data,
       url: "https://github.com/cosmos/sdk-tutorials/blob/c6754a1e313eb1ed973c5c91dcc606f2fd288811/deeply/nested/hidden/directory/go.mod#L1-L18",
+      base64: "Ly8gVXBkYXRlIHRoZSB2YWxpZGF0b3Igc2V0CmZ1bmMgKGFwcCAqUGVyc2lzdGVudEtWU3RvcmVBcHBsaWNhdGlvbikgRW5kQmxvY2socmVxIHR5cGVzLlJlcXVlc3RFbmRCbG9jaykgdHlwZXMuUmVzcG9uc2VFbmRCbG9jayB7CglyZXR1cm4gdHlwZXMuUmVzcG9uc2VFbmRCbG9ja3tWYWxpZGF0b3JVcGRhdGVzOiBhcHAuVmFsVXBkYXRlc30KfQo="
     }
   },
   template: `
@@ -22,6 +23,8 @@ export const normal = () => ({
       <code-block :value="data.medium" language="go"/>
       <p>Multiline snippet with an expand button:</p>
       <code-block :value="data.long" :url="url" language="xyz"/>
+      <p>Base64:</p>
+      <code-block :base64="base64" language="go"/>
     </div>
   `
 });

--- a/src/CodeBlock/CodeBlock.vue
+++ b/src/CodeBlock/CodeBlock.vue
@@ -154,6 +154,10 @@ span {
 .codeblock__expanded__false .expand {
   background: linear-gradient(180deg, rgba(22, 25, 49, 0) 0%, #161931 100%);
 }
+.codeblock__hasfooter__false.codeblock__expanded__false .expand {
+  border-bottom-left-radius: 0.5rem;
+  border-bottom-right-radius: 0.5rem;
+}
 .expand__item {
   text-transform: uppercase;
   background-color: #dadce6;

--- a/src/CodeBlock/CodeBlock.vue
+++ b/src/CodeBlock/CodeBlock.vue
@@ -15,7 +15,7 @@
             </span>
             <span class="icons__item">
               <svg class="icons__item__icon" width="24" height="24" viewBox="0 0 24 24" 
-                xmlns="http://www.w3.org/2000/svg" @click="copy(value)">
+                xmlns="http://www.w3.org/2000/svg" @click="copy(source)">
                 <path fill-rule="evenodd" clip-rule="evenodd" d="M11 0.25C10.0335 0.25 9.25 1.0335 9.25 2V4.5H10.75V2C10.75 1.86193 10.8619 1.75 11 1.75H21C21.1381 1.75 21.25 1.86193 21.25 2V16C21.25 16.1381 21.1381 16.25 21 16.25H16.5V17.75H21C21.9665 17.75 22.75 16.9665 22.75 16V2C22.75 1.0335 21.9665 0.25 21 0.25H11ZM3 6.25C2.0335 6.25 1.25 7.0335 1.25 8V22C1.25 22.9665 2.0335 23.75 3 23.75H13C13.9665 23.75 14.75 22.9665 14.75 22V8C14.75 7.0335 13.9665 6.25 13 6.25H3ZM2.75 8C2.75 7.86193 2.86193 7.75 3 7.75H13C13.1381 7.75 13.25 7.86193 13.25 8V22C13.25 22.1381 13.1381 22.25 13 22.25H3C2.86193 22.25 2.75 22.1381 2.75 22V8Z"></path>
               </svg>
               <span class="icons__item__tooltip">
@@ -25,7 +25,7 @@
           </span>
           <span class="body" :style="{'--max-height': maxHeight}" ref="body">
             <span class="body__wrapper">
-              <span class="body__code" v-html="highlighted(value)"></span>
+              <span class="body__code" v-html="highlighted(source)"></span>
             </span>
           </span>
         </span>
@@ -331,6 +331,12 @@ export default {
       type: String,
     },
     /**
+     * Code rendered in the body of the block in base64
+     */
+    base64: {
+      type: String
+    },
+    /**
      * URL for "View source" link and filename in the code-block's footer
      */
     url: {
@@ -353,6 +359,10 @@ export default {
     };
   },
   computed: {
+    source() {
+      if (this.base64) return atob(this.base64)
+      return this.value
+    },
     out() {
       return this.$slots.default;
     }
@@ -400,7 +410,8 @@ export default {
       const container = this.$refs.container;
       this.expanded = bool;
       if (!bool && container && scroll) container.scrollIntoView();
-    }
+    },
+    atob
   }
 };
 </script>

--- a/src/CodeBlock/CodeBlock.vue
+++ b/src/CodeBlock/CodeBlock.vue
@@ -325,6 +325,7 @@ span {
 import Prism from "prismjs";
 import "prismjs/components/prism-go.js";
 import copy from "clipboard-copy";
+import { Base64 } from 'js-base64';
 
 export default {
   props: {
@@ -364,7 +365,7 @@ export default {
   },
   computed: {
     source() {
-      if (this.base64) return atob(this.base64)
+      if (this.base64) return Base64.decode(this.base64)
       return this.value
     },
     out() {
@@ -372,10 +373,12 @@ export default {
     }
   },
   mounted() {
-    this.isExpandable = this.$refs.body.scrollHeight > 1000;
-    this.height = this.$refs.body.scrollHeight - 700;
-    this.expanded = this.$refs.body.scrollHeight - 700 < 300;
-    this.maxHeight = this.$refs.body.scrollHeight + "px";
+    if (this.$refs.body) {
+      this.isExpandable = this.$refs.body.scrollHeight > 1000;
+      this.height = this.$refs.body.scrollHeight - 700;
+      this.expanded = this.$refs.body.scrollHeight - 700 < 300;
+      this.maxHeight = this.$refs.body.scrollHeight + "px";
+    }
   },
   methods: {
     filename(url) {
@@ -414,8 +417,7 @@ export default {
       const container = this.$refs.container;
       this.expanded = bool;
       if (!bool && container && scroll) container.scrollIntoView();
-    },
-    atob
+    }
   }
 };
 </script>


### PR DESCRIPTION
Added `base64` prop that accepts a string and decodes it using `atob()`. This is necessary, because in some cases code block content contains special characters that trigger Vue's interpolation. For example, `<code-block value="{{x:2}}"/>` raises an error, because props should not contain `{{` and `}}`.

Instead, `<code-block base64="e3t4OjJ9fQ=="/>`.

Also, this PR fixes border-radius when a footer can expand (has an expand button), but doesn't have a footer.

https://github.com/allinbits/design/issues/227