### PR TITLE
Modal bugfix

### DIFF
--- a/src/Modal/Modal.vue
+++ b/src/Modal/Modal.vue
@@ -334,6 +334,7 @@ export default {
   },
   methods: {
     adjustVertically() {
+      if (!this.$refs.content) return
       const
         content = this.$refs.content.offsetHeight,
         height = window.innerHeight,


### PR DESCRIPTION
Small bug that throws `undefined` error if `this.$refs.content` is missing.

<img width="1417" alt="Screenshot 2020-04-07 at 19 13 48" src="https://user-images.githubusercontent.com/332151/78679828-26712200-7904-11ea-81dd-c7d69f90383d.png">

Related: https://github.com/tendermint/tendermint.com/pull/463