### PR TITLE
Signup form: replace event with campaign

### DIFF
--- a/src/SeriesSignup/SeriesSignup.vue
+++ b/src/SeriesSignup/SeriesSignup.vue
@@ -321,7 +321,7 @@ export default {
         },
         body: querystring.stringify({
           "CONTACT_EMAIL": this.email,
-          "CONTACT_CF15": urlParams.get("utm_event"),
+          "CONTACT_CF15": urlParams.get("utm_campaign"),
           "CONTACT_CF31": urlParams.get("utm_source"),
           ...this.formData
         })


### PR DESCRIPTION
By default Google Analytics uses `utm_campaign` parameter. We might as well stick to that convention, so that it's easier to track things in GA. (unless there is a reason, why we shouldn't)

<img width="1405" alt="Screenshot 2020-05-20 at 16 34 29" src="https://user-images.githubusercontent.com/332151/82441819-f21e8300-9ab7-11ea-984b-4c31a3e422e8.png">
