### PR TITLE
CodeBlock Fonts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cosmos-ui/vue",
-  "version": "0.30.0",
+  "version": "0.33.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/CodeBlock/CodeBlock.stories.js
+++ b/src/CodeBlock/CodeBlock.stories.js
@@ -27,7 +27,7 @@ export const normal = () => ({
       <code-block :base64="base64" language="go"/>
       <p>Rust source:</p>
       <code-block :value="data.rust" language="rust"/>
-      <p>Python source:</p>
+      <p>Python prismjs package is not imported:</p>
       <code-block :value="data.python" language="python"/>
     </div>
   `

--- a/src/CodeBlock/CodeBlock.stories.js
+++ b/src/CodeBlock/CodeBlock.stories.js
@@ -25,6 +25,10 @@ export const normal = () => ({
       <code-block :value="data.long" :url="url" language="xyz"/>
       <p>Base64:</p>
       <code-block :base64="base64" language="go"/>
+      <p>Rust source:</p>
+      <code-block :value="data.rust" language="rust"/>
+      <p>Python source:</p>
+      <code-block :value="data.python" language="python"/>
     </div>
   `
 });

--- a/src/CodeBlock/CodeBlock.vue
+++ b/src/CodeBlock/CodeBlock.vue
@@ -202,6 +202,9 @@ span {
 }
 .body__wrapper {
   font-family: 'JetBrains Mono', 'arial', 'Menlo', 'Monaco', monospace;
+  -webkit-font-feature-settings: "liga" on, "calt" on;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
   font-size: 0.8125rem;
   display: inline-block;
   line-height: 1.25rem;

--- a/src/CodeBlock/CodeBlock.vue
+++ b/src/CodeBlock/CodeBlock.vue
@@ -402,7 +402,10 @@ span {
 import Prism from "prismjs";
 import "prismjs/components/prism-go.min.js";
 import "prismjs/components/prism-rust.min.js";
-// import "prismjs/components/prism-python.min.js";
+import "prismjs/components/prism-markdown.min.js";
+import "prismjs/components/prism-bash.min.js";
+import "prismjs/components/prism-json.min.js";
+import "prismjs/components/prism-protobuf.min.js";
 import copy from "clipboard-copy";
 import { Base64 } from "js-base64";
 

--- a/src/CodeBlock/CodeBlock.vue
+++ b/src/CodeBlock/CodeBlock.vue
@@ -201,7 +201,7 @@ span {
   max-height: var(--max-height);
 }
 .body__wrapper {
-  font-family: "Menlo", "Monaco", "Fira Code", monospace;
+  font-family: 'JetBrains Mono', 'arial', 'Menlo', 'Monaco', monospace;
   font-size: 0.8125rem;
   display: inline-block;
   line-height: 1.25rem;

--- a/src/CodeBlock/CodeBlock.vue
+++ b/src/CodeBlock/CodeBlock.vue
@@ -201,7 +201,7 @@ span {
   max-height: var(--max-height);
 }
 .body__wrapper {
-  font-family: "JetBrains Mono", "arial", "Menlo", "Monaco", monospace;
+  font-family: "JetBrains Mono", "Menlo", "Monaco", monospace;
   -webkit-font-feature-settings: "liga" on, "calt" on;
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;

--- a/src/CodeBlock/CodeBlock.vue
+++ b/src/CodeBlock/CodeBlock.vue
@@ -201,7 +201,7 @@ span {
   max-height: var(--max-height);
 }
 .body__wrapper {
-  font-family: 'JetBrains Mono', 'arial', 'Menlo', 'Monaco', monospace;
+  font-family: "JetBrains Mono", "arial", "Menlo", "Monaco", monospace;
   -webkit-font-feature-settings: "liga" on, "calt" on;
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
@@ -400,7 +400,9 @@ span {
 
 <script>
 import Prism from "prismjs";
-import "prismjs/components/prism-go.js";
+import "prismjs/components/prism-go.min.js";
+import "prismjs/components/prism-rust.min.js";
+// import "prismjs/components/prism-python.min.js";
 import copy from "clipboard-copy";
 import { Base64 } from "js-base64";
 

--- a/src/CodeBlock/data.js
+++ b/src/CodeBlock/data.js
@@ -1,5 +1,13 @@
 export default {
   short: 'type AppModuleBasic struct{}" "',
+  rust: `
+pub trait Actor {
+  fn handle(msgPayload: &[u8]) -> Vec<Msg>;
+}
+  `,
+  python: `
+  print("hello, world.")
+  `,
   medium: `// BeginBlocker sets the proposer for determining distribution during endblock
 // and distribute rewards for the previous block
 func \"BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock, k keeper.Keeper) {


### PR DESCRIPTION
https://deploy-preview-201--cosmos-ui.netlify.app/?path=/story/codeblock--normal

- added `JetBrains Mono` to font-family.
- font changes
- added more prismjs languages support: rust, markdown, bash, json, protobuf

Related:
- https://www.jetbrains.com/lp/mono/
- https://github.com/JetBrains/JetBrainsMono#chromeos-terminal