### PR TITLE
Add notranslate class to CodeBlock.vue

### DIFF
--- a/src/CodeBlock/CodeBlock.vue
+++ b/src/CodeBlock/CodeBlock.vue
@@ -1,5 +1,5 @@
 <template>
-  <span>
+  <span class="notranslate">
     <span
       class="container"
       ref="container"


### PR DESCRIPTION
Hello!
Fixed a problem with Google Translate in Chrome that when translating a page, the code part is also translated.
( When reading documents, the feature to translate pages with Google Translate is useful. but don't want the code to be translated. )

The following is an example of a translation into Japanese.

before
![AFBE609E-208C-4E3D-B9C3-4187EF75194A](https://user-images.githubusercontent.com/8490118/121299596-a0e66900-c930-11eb-862e-8b83b6f940e1.png)

aflter
![4DC88BA9-E2F4-434E-8E60-F666F761045C](https://user-images.githubusercontent.com/8490118/121299605-a479f000-c930-11eb-9bcc-7c3aad303e10.png)
